### PR TITLE
Add Registax

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Contributions are welcome. Please read the [contributing guideline](CONTRIBUTING
 - [BlurXTerminator](https://www.rc-astro.com/resources/BlurXTerminator/) - An AI based deconvolution tool. Currently only available as a process module plug-in for PixInsight.
 - [DeepSkyStacker](http://deepskystacker.free.fr/english/index.html) - Registering, stacking, and simple post-processing.
 - [PixInsight](https://pixinsight.com) - Advanced image processing software platform. Very powerful but the user interface is intimidating.
+- [Registax](https://www.astronomie.be/registax/) - Planetary image processing with wavelet sharpening and frame stacking.
 - [Siril](https://siril.org) - Registering, stacking, and post-processing, specially tailored for noise reduction and improving the signal-to-noise ratio.
 - [StarNet++](https://sourceforge.net/projects/starnet/) - A simple program that allows the removal of the stars from astrophotography images.
 


### PR DESCRIPTION
Adds [Registax](https://www.astronomie.be/registax/) to the Image Processing section.

Registax is a classic planetary image processing tool known for its wavelet sharpening capabilities and frame stacking. It has been widely used in the astrophotography community for processing planetary, lunar, and solar images.