### PR TITLE
Add PIPP

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ Contributions are welcome. Please read the [contributing guideline](CONTRIBUTING
 - [Adobe Photoshop](https://www.adobe.com/products/photoshop.html) - Advanced and very powerful software for post-processing.
 - [BlurXTerminator](https://www.rc-astro.com/resources/BlurXTerminator/) - An AI based deconvolution tool. Currently only available as a process module plug-in for PixInsight.
 - [DeepSkyStacker](http://deepskystacker.free.fr/english/index.html) - Registering, stacking, and simple post-processing.
+- [PIPP](https://sites.google.com/site/astropipp/) - Planetary Imaging PreProcessor for preparing captures before stacking.
 - [PixInsight](https://pixinsight.com) - Advanced image processing software platform. Very powerful but the user interface is intimidating.
 - [Siril](https://siril.org) - Registering, stacking, and post-processing, specially tailored for noise reduction and improving the signal-to-noise ratio.
 - [StarNet++](https://sourceforge.net/projects/starnet/) - A simple program that allows the removal of the stars from astrophotography images.


### PR DESCRIPTION
Adds [PIPP](https://sites.google.com/site/astropipp/) (Planetary Imaging PreProcessor) to the Image Processing section.

PIPP is a preprocessing tool commonly used to prepare planetary, lunar, and solar captures before stacking in tools like AutoStakkert or Registax. It handles tasks such as cropping, centering, quality sorting, and format conversion.